### PR TITLE
fix: add OpenAI max_tokens/max_completion_tokens compatibility layer

### DIFF
--- a/fastcode/answer_generator.py
+++ b/fastcode/answer_generator.py
@@ -11,6 +11,7 @@ from openai import OpenAI
 from anthropic import Anthropic
 from dotenv import load_dotenv
 
+from .llm_utils import openai_chat_completion
 from .utils import count_tokens, truncate_to_tokens
 
 
@@ -637,7 +638,8 @@ Symbol Mappings:
             return "Error: OpenAI client not initialized"
 
         try:
-            response = self.client.chat.completions.create(
+            response = openai_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=self.temperature,
@@ -667,7 +669,8 @@ Symbol Mappings:
             return
 
         try:
-            response = self.client.chat.completions.create(
+            response = openai_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=self.temperature,

--- a/fastcode/iterative_agent.py
+++ b/fastcode/iterative_agent.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 import numpy as np
 
 from .agent_tools import AgentTools
+from .llm_utils import openai_chat_completion
 from .path_utils import PathUtils
 
 
@@ -2473,7 +2474,8 @@ If continuing (confidence < {self.confidence_threshold} and budget available):
         self.logger.info(f"Calling LLM: prompt_len={len(prompt)}, max_tokens={self.max_tokens}")
 
         if self.provider == "openai":
-            response = self.client.chat.completions.create(
+            response = openai_chat_completion(
+                self.client,
                 model=self.model,
                 messages=[
                     {"role": "system", "content": "You are a precise code analysis agent. Respond in specified format only."},

--- a/fastcode/llm_utils.py
+++ b/fastcode/llm_utils.py
@@ -1,0 +1,17 @@
+from openai import BadRequestError
+
+
+def openai_chat_completion(client, *, max_tokens, **kwargs):
+    """Call OpenAI-compatible chat completions with max_tokens fallback.
+
+    Tries max_tokens first (broadest compatibility), falls back to
+    max_completion_tokens if the model rejects max_tokens (e.g. gpt-5.2, o1).
+    """
+    try:
+        return client.chat.completions.create(max_tokens=max_tokens, **kwargs)
+    except BadRequestError as e:
+        if "max_tokens" in str(e) and "max_completion_tokens" in str(e):
+            return client.chat.completions.create(
+                max_completion_tokens=max_tokens, **kwargs
+            )
+        raise

--- a/fastcode/query_processor.py
+++ b/fastcode/query_processor.py
@@ -11,6 +11,8 @@ from openai import OpenAI
 from anthropic import Anthropic
 from dotenv import load_dotenv
 
+from .llm_utils import openai_chat_completion
+
 
 @dataclass
 class ProcessedQuery:
@@ -589,7 +591,8 @@ Be concise and focus on improving code retrieval accuracy."""
     
     def _call_openai(self, prompt: str) -> str:
         """Call OpenAI API for query enhancement"""
-        response = self.llm_client.chat.completions.create(
+        response = openai_chat_completion(
+            self.llm_client,
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
             temperature=self.temperature,

--- a/fastcode/repo_overview.py
+++ b/fastcode/repo_overview.py
@@ -10,6 +10,8 @@ from openai import OpenAI
 from anthropic import Anthropic
 from dotenv import load_dotenv
 
+from .llm_utils import openai_chat_completion
+
 
 class RepositoryOverviewGenerator:
     """Generate repository overviews from README files and file structure"""
@@ -254,7 +256,8 @@ Summary:"""
         
         try:
             if self.provider == "openai":
-                response = self.llm_client.chat.completions.create(
+                response = openai_chat_completion(
+                    self.llm_client,
                     model=self.model,
                     messages=[{"role": "user", "content": prompt}],
                     temperature=self.temperature,

--- a/fastcode/repo_selector.py
+++ b/fastcode/repo_selector.py
@@ -10,6 +10,8 @@ from anthropic import Anthropic
 from dotenv import load_dotenv
 import re
 
+from .llm_utils import openai_chat_completion
+
 
 class RepositorySelector:
     """Use LLM to select relevant repositories and files based on user query"""
@@ -186,7 +188,8 @@ class RepositorySelector:
     
     def _call_openai(self, prompt: str) -> str:
         """Call OpenAI API"""
-        response = self.llm_client.chat.completions.create(
+        response = openai_chat_completion(
+            self.llm_client,
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
             temperature=self.temperature,


### PR DESCRIPTION
## Summary
- Newer OpenAI models (gpt-5.2, o1) reject the `max_tokens` parameter and require `max_completion_tokens` instead, causing `BadRequestError` at runtime
- Added `fastcode/llm_utils.py` with a central `openai_chat_completion()` helper that tries `max_tokens` first and falls back to `max_completion_tokens` on error
- Updated all 6 OpenAI API call sites across 5 files to use the helper, maintaining full backward compatibility with older models and other providers (Anthropic, Ollama, OpenRouter)

## Changes
| File | Change |
|------|--------|
| `fastcode/llm_utils.py` | **New** — `openai_chat_completion()` helper with try/except fallback |
| `fastcode/iterative_agent.py` | Use helper in `_call_llm()` |
| `fastcode/answer_generator.py` | Use helper in `_generate_openai()` and `_generate_openai_stream()` |
| `fastcode/query_processor.py` | Use helper in `_call_openai()` |
| `fastcode/repo_selector.py` | Use helper in `_call_openai()` |
| `fastcode/repo_overview.py` | Use helper in `_summarize_readme_with_llm()` |

## Test plan
- [ ] Verify with a newer model (e.g. gpt-5.2) that the fallback to `max_completion_tokens` works
- [ ] Verify with an older model (e.g. gpt-4o) that `max_tokens` still works on first try
- [ ] Verify Anthropic provider path is unaffected