### PR TITLE
Add stop button to abort response generation

### DIFF
--- a/web_interface.html
+++ b/web_interface.html
@@ -380,6 +380,11 @@
                         <button onclick="sendMessage()" id="send-btn" class="bg-teal-600 text-white p-2 rounded-lg hover:bg-teal-700 transition disabled:opacity-50 disabled:cursor-not-allowed shadow-sm" disabled>
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"/></svg>
                         </button>
+                        <button onclick="stopGeneration()" id="stop-btn" class="bg-red-500 text-white p-2 rounded-lg hover:bg-red-600 transition shadow-sm hidden">
+                            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                                <rect x="6" y="6" width="12" height="12" rx="2"/>
+                            </svg>
+                        </button>
                     </div>
                 </div>
             </div>
@@ -413,6 +418,8 @@
         chatMode: false, // false = single, true = multi
         messages: []
     };
+
+    let currentAbortController = null;
 
     // --- MARKDOWN SETUP ---
     const mdRenderer = new marked.Renderer();
@@ -459,7 +466,11 @@
         input.addEventListener('keydown', (e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
-                sendMessage();
+                if (state.isSending) {
+                    stopGeneration();
+                } else {
+                    sendMessage();
+                }
             }
         });
 
@@ -499,6 +510,16 @@
         const canSend = state.ready && state.selectedRepos.length > 0 && !state.isSending;
         document.getElementById('message-input').disabled = !canSend;
         document.getElementById('send-btn').disabled = !canSend;
+
+        const sendBtn = document.getElementById('send-btn');
+        const stopBtn = document.getElementById('stop-btn');
+        if (state.isSending) {
+            sendBtn.classList.add('hidden');
+            stopBtn.classList.remove('hidden');
+        } else {
+            sendBtn.classList.remove('hidden');
+            stopBtn.classList.add('hidden');
+        }
     }
 
     function renderRepoList(filter = '') {
@@ -645,6 +666,7 @@
         }
 
         try {
+            currentAbortController = new AbortController();
             const response = await fetch('/api/query-stream', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -653,7 +675,8 @@
                     repo_filter: state.selectedRepos,
                     multi_turn: state.chatMode,
                     session_id: state.sessionId
-                })
+                }),
+                signal: currentAbortController.signal
             });
 
             if (!response.ok) {
@@ -750,7 +773,19 @@
         } catch (e) {
             const contentEl = document.getElementById(`${streamId}-content`);
             if (contentEl) {
-                contentEl.innerHTML = `<span class="text-red-500">Error: ${escapeHtml(e.message)}</span>`;
+                if (e.name === 'AbortError') {
+                    if (renderTimeout) {
+                        clearTimeout(renderTimeout);
+                        renderTimeout = null;
+                    }
+                    if (fullContent) {
+                        contentEl.innerHTML = marked.parse(fullContent);
+                    } else {
+                        contentEl.textContent = 'Response stopped.';
+                    }
+                } else {
+                    contentEl.innerHTML = `<span class="text-red-500">Error: ${escapeHtml(e.message)}</span>`;
+                }
             }
         } finally {
             // Clean up scroll listener
@@ -758,8 +793,16 @@
             if (renderTimeout) {
                 clearTimeout(renderTimeout);
             }
+            currentAbortController = null;
             state.isSending = false;
             updateUIStatus();
+        }
+    }
+
+    function stopGeneration() {
+        if (currentAbortController) {
+            currentAbortController.abort();
+            currentAbortController = null;
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds a stop button that replaces the send button during response streaming, allowing users to abort in-flight queries
- Pressing Enter during generation also triggers stop (instead of being a no-op)
- Partial markdown responses are preserved and rendered; if stopped before any content arrives, shows "Response stopped."
- No backend changes needed — aborting the fetch causes FastAPI's StreamingResponse to detect the disconnect naturally

## Changes

All changes are in `web_interface.html` (single-page web UI):

- **Stop button HTML**: Red square-icon button next to send button, hidden by default
- **AbortController integration**: Created before each fetch, signal passed to request options
- **`stopGeneration()` function**: Calls `abort()` on the active controller
- **`AbortError` handling**: Gracefully renders partial content or shows stop message
- **Button visibility toggle**: `updateUIStatus()` swaps send/stop based on `isSending` state
- **Enter key behavior**: Triggers stop during generation instead of attempting a new send
- **Cleanup**: Controller reference nullified in the `finally` block

## Test plan

- [ ] Send a query and confirm the send button transforms into a red stop button
- [ ] Click stop during "Retrieving context..." phase — should show "Response stopped."
- [ ] Click stop during streaming text — should keep the partial markdown response
- [ ] After stopping, confirm stop button reverts to send and input is re-enabled
- [ ] Send another query after stopping to confirm normal flow works
- [ ] Let a query complete without stopping to confirm the stop button disappears
- [ ] Press Enter during generation to confirm it triggers stop