### PR TITLE
Fix embedder to use Apple Silicon MPS when available

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -60,7 +60,7 @@ embedding:
   model: "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"  # Multilingual support (470MB)
   # model: "sentence-transformers/all-MiniLM-L6-v2"  # Faster download but English only (90MB)
   # Alternative: "BAAI/bge-large-en-v1.5" for better quality
-  device: "cuda"  # or "cpu"
+  device: "auto"  # "auto" (recommended), "cuda", "mps", or "cpu"
   batch_size: 32
   max_seq_length: 512
   normalize_embeddings: true

--- a/fastcode/embedder.py
+++ b/fastcode/embedder.py
@@ -19,15 +19,14 @@ class CodeEmbedder:
         self.logger = logging.getLogger(__name__)
         
         self.model_name = self.embedding_config.get("model", "sentence-transformers/all-MiniLM-L6-v2")
-        self.device = self.embedding_config.get("device", "cpu")
+        self.device = self.embedding_config.get("device", "auto")
         self.batch_size = self.embedding_config.get("batch_size", 32)
         self.max_seq_length = self.embedding_config.get("max_seq_length", 512)
         self.normalize = self.embedding_config.get("normalize_embeddings", True)
         
-        # Check for CUDA availability
-        if self.device == "cuda" and not torch.cuda.is_available():
-            self.logger.warning("CUDA not available, falling back to CPU")
-            self.device = "cpu"
+        # Auto-detect best available device: CUDA > MPS > CPU
+        if self.device != "cpu":
+            self.device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
         
         self.logger.info(f"Loading embedding model: {self.model_name}")
         self.model = self._load_model()


### PR DESCRIPTION
## Summary
- The embedder only checked for CUDA availability and fell back to CPU, completely ignoring the MPS backend on Apple Silicon Macs. M-series GPUs were never utilized for embedding computation.
- Replaced the CUDA-only fallback with a priority chain: **CUDA > MPS > CPU**. Changed the default device config from `"cuda"` to `"auto"` so it works optimally across all platforms without manual configuration.

## Changes
- **`fastcode/embedder.py`**: Auto-detect best available device instead of only checking CUDA. Default changed from `"cpu"` to `"auto"`.
- **`config/config.yaml`**: Device setting changed from `"cuda"` to `"auto"` with updated comment listing all options.

## Test plan
- Verified on Apple Silicon (M-series) Mac: `Device: mps` is correctly selected
- No more spurious "CUDA not available, falling back to CPU" warning in logs
- Explicit `device: "cpu"` in config still respected (bypasses auto-detection)
- CUDA systems unaffected (CUDA is checked first in the priority chain)