### PR TITLE
fix(mcp): fix SSE transport host binding and remove invalid sse_params kwarg

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -186,7 +186,12 @@ except (TypeError, ValueError):
     # If signature introspection fails, fall back to the safest constructor shape.
     pass
 
-mcp = FastMCP("FastCode", **_fastmcp_kwargs)
+mcp = FastMCP(
+    "FastCode",
+    host=os.getenv("FASTMCP_HOST", "0.0.0.0"),
+    port=int(os.getenv("FASTMCP_PORT", "8080")),
+    **_fastmcp_kwargs,
+)
 
 
 @mcp.tool()
@@ -419,6 +424,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.transport == "sse":
-        mcp.run(transport="sse", sse_params={"port": args.port})
+        mcp.run(transport="sse")
     else:
         mcp.run(transport="stdio")


### PR DESCRIPTION
## Problem

Two bugs prevent the MCP SSE transport from working:

**1. `TypeError` on startup**

`mcp.run()` is called with `sse_params={"port": args.port}` but the `mcp` library's `FastMCP.run()` does not accept a `sse_params` keyword argument, causing an immediate crash:

```
TypeError: FastMCP.run() got an unexpected keyword argument 'sse_params'
```

**2. SSE server binds to `127.0.0.1` (localhost only)**

`FastMCP` defaults to `host="127.0.0.1"`, so when running SSE transport the server is unreachable from any other machine — making remote MCP clients (Claude Code, Cursor, etc.) unable to connect.

## Fix

- Pass `host` and `port` directly to the `FastMCP` constructor, defaulting to `0.0.0.0:8080` with overrides via `FASTMCP_HOST` / `FASTMCP_PORT` env vars
- Remove the invalid `sse_params` kwarg from `mcp.run()`

Note: the `--port` CLI arg was already a no-op since `FastMCP` is instantiated at module level before args are parsed. Users should use `FASTMCP_PORT` env var to configure the port.

## Usage after fix

```bash
# default port 8080, all interfaces
python mcp_server.py --transport sse

# custom port
FASTMCP_PORT=8091 python mcp_server.py --transport sse

# localhost only
FASTMCP_HOST=127.0.0.1 python mcp_server.py --transport sse
```