### PR TITLE
fix: remove duplicate FastCode export in __all__

### DIFF
--- a/fastcode/__init__.py
+++ b/fastcode/__init__.py
@@ -28,7 +28,6 @@ FastCode = FastCode
 
 __all__ = [
     "FastCode",
-    "FastCode",
     "RepositoryLoader",
     "CodeParser",
     "CodeIndexer",


### PR DESCRIPTION
## Summary

Remove duplicate 'FastCode' entry from __all__ list in fastcode/__init__.py.

## Changes Made

- Removed duplicate "FastCode" string from __all__ export list

## Testing

- Verified no functional impact (duplicate in __all__ has no effect)
- File syntax remains valid

## Checklist

- [x] Code follows project style
- [x] No functional changes
- [x] Self-reviewed