### PR TITLE
fix(path_utils): anchor is_safe_path containment on a separator boundary

### DIFF
--- a/fastcode/path_utils.py
+++ b/fastcode/path_utils.py
@@ -258,8 +258,14 @@ class PathUtils:
             if resolved is None:
                 # Also check if the joined path would be safe (even if doesn't exist yet)
                 abs_path = os.path.abspath(os.path.join(self.repo_root, path))
-                return abs_path.startswith(self.repo_root)
-            return resolved.startswith(self.repo_root)
+            else:
+                abs_path = resolved
+            # Require an exact match or a path-separator boundary, so a sibling
+            # directory that merely shares the repo-root name prefix (e.g.
+            # "myrepo_secrets" vs "myrepo") or a "../" escape onto it is not
+            # treated as inside the repository.
+            return (abs_path == self.repo_root
+                    or abs_path.startswith(self.repo_root + os.sep))
         except Exception as e:
             self.logger.warning(f"Path security check failed for {path}: {e}")
             return False


### PR DESCRIPTION
## Problem

`PathUtils.is_safe_path` (`fastcode/path_utils.py`) — the repository-containment security check delegated to by `AgentTools._is_safe_path` and used as the first gate in every agent read tool (`list_directory`, `search_codebase`, `get_file_info`, `get_file_structure_summary`, `read_file_content`) — tests containment with a bare `startswith`:

```python
resolved = self.resolve_path(path)
if resolved is None:
    abs_path = os.path.abspath(os.path.join(self.repo_root, path))
    return abs_path.startswith(self.repo_root)
return resolved.startswith(self.repo_root)
```

`self.repo_root` has no trailing separator, so any path whose absolute form merely *begins with the repo-root string* passes — including a **sibling directory that shares the name prefix** and `../` escapes onto it.

## Reproduction

Repo root `.../myrepo`, sibling `.../myrepo_secrets` outside it (verified against the real `PathUtils`):

| call | before | after |
|---|---|---|
| `is_safe_path("../myrepo_secrets/passwords.txt")` | `True` ❌ | `False` |
| `is_safe_path("../myrepo_secrets")` | `True` ❌ | `False` |
| `is_safe_path("../myrepo2")` | `True` ❌ | `False` |
| `is_safe_path(".")` / `is_safe_path("sub/f.py")` | `True` | `True` |

A wrongly-permissive result lets the exploration agent read/list files outside the intended repository boundary.

## Fix

Require an exact match or a path-separator boundary:

```python
return (abs_path == self.repo_root
        or abs_path.startswith(self.repo_root + os.sep))
```

This is the same containment discipline the sibling function `file_path_to_module_path` in this file already applies (it was deliberately rewritten to use `os.path.commonpath`, per its comment *"prevents path traversal attacks and handles edge cases like root directories"*) — `is_safe_path` just wasn't given the same treatment.

Verified RED→GREEN against the real `PathUtils` (module is stdlib-only); `python -m py_compile` passes. (No test suite exists in the repo; the reproduction above is the RED→GREEN check.)
